### PR TITLE
feat: Add youtube-dl installer and various fixes

### DIFF
--- a/assets/youtube-dl/config
+++ b/assets/youtube-dl/config
@@ -1,0 +1,13 @@
+--no-mtime
+--embed-metadata
+--embed-thumbnail
+--embed-chapters
+--embed-subs
+# --sub-format srt
+# --convert-subs srt
+-P "$HOME/storage/shared/Youtube-DL/"
+-o "%(title).40s.%(ext)s"
+--windows-filenames
+--write-subs
+--playlist-reverse
+--no-abort-on-error

--- a/assets/youtube-dl/sponsorblock.conf
+++ b/assets/youtube-dl/sponsorblock.conf
@@ -1,0 +1,2 @@
+--sponsorblock-remove all
+--config-locations "$HOME/.config/yt-dlp/config"

--- a/assets/youtube-dl/termux-url-opener
+++ b/assets/youtube-dl/termux-url-opener
@@ -1,0 +1,125 @@
+#!/bin/bash
+clear
+
+DOWNLOAD_PATH="$HOME/storage/shared/Youtube-DL/"
+PLAYLIST="%(extractor)s/playlists/%(playlist_title)s_%(playlist_id)s/%(n_entries-playlist_index)03d - %(uploader)s - %(title)s [%(id)s].%(ext)s"
+CHANNEL="%(extractor)s/channel/%(uploader)s_%(channel_id)s/%(title)s [%(id)s].%(ext)s"
+CONFIG_PATH="$HOME/.config/yt-dlp/"
+NC='\033[0m'
+
+function echo_bold() { echo -ne "\033[0;1;34m${*}${NC}\n"; }
+function echo_success() { echo -ne "\033[1;32m${*}${NC}\n"; }
+function echo_warning() { echo -ne "\033[1;33m${*}${NC}\n"; }
+function echo_danger() { echo -ne "\033[1;31m${*}${NC}\n"; }
+function echo_error() { echo -ne "\033[0;1;31merror:\033[0;31m\t${*}${NC}\n"; }
+
+function isSponsorblockAlive() {
+    #* HTTP/2 400 = bad request = api is working 1
+    #* HTTP/2 200 = ok = api is working 1
+    #! HTTP/2 404 = not found = api is not working 0
+    #! HTTP/2 500 = internal server error = api is not working 0
+    res=$(curl -Is https://sponsor.ajay.app/api/skipSegments | grep "HTTP" | awk '{print $2}')
+    if [ "$res" == "200" ] || [ "$res" == "400" ]; then
+        echo_success "sponsorblock api is working"
+        return 1
+    else
+        echo_warning "sponsorblock api is not working"
+        return 0
+    fi
+}
+
+function downloadVideo() {
+    echo -e "\\nDownloading video...\\n"
+    yt-dlp --config-locations "${CONFIG_PATH}config" -F "$1"
+    echo_warning "Choose your video quality (<enter> for: 'best'):"
+    read -p "" video
+    echo_warning "Choose your audio quality (<enter> for: 'best'):"
+    read -p "" audio
+    echo_warning "Input video name:"
+    read -p "" name
+
+    if [[ "$video" = "" ]]; then
+        video="best"
+    fi
+    if [[ "$audio" = "" ]]; then
+        audio="best"
+    fi
+    if [[ "$name" = "" ]]; then
+        name="%(title).40s [%(id)s].%(ext)s"
+    fi
+    if isSponsorblockAlive; then
+        # sucess
+        yt-dlp --config-locations "${CONFIG_PATH}sponsorblock.conf" -P "$DOWNLOAD_PATH" -o "$name" -f "$video"+"$audio" "$1"
+    else
+        # fail
+        yt-dlp --config-locations "${CONFIG_PATH}config" -P "$DOWNLOAD_PATH" -o "$name" -f "$video"+"$audio" "$1"
+    fi
+}
+
+function downloadChannel() {
+    echo "Downloading channel..."
+    if isSponsorblockAlive; then
+        yt-dlp --config-locations "${CONFIG_PATH}sponsorblock.conf" -P "$DOWNLOAD_PATH" -o "$CHANNEL" "$1"
+    else
+        yt-dlp --config-locations "${CONFIG_PATH}config" -P "$DOWNLOAD_PATH" -o "$CHANNEL" "$1"
+    fi
+}
+
+function downloadPlaylist() {
+    echo "Downloading playlist..."
+    if isSponsorblockAlive; then
+        yt-dlp --config-locations "${CONFIG_PATH}sponsorblock.conf" -P "$DOWNLOAD_PATH" -o "$PLAYLIST" "$1"
+    else
+        yt-dlp --config-locations "${CONFIG_PATH}config" -P "$DOWNLOAD_PATH" -o "$PLAYLIST" "$1"
+    fi
+}
+
+function downloadAudio() {
+    echo "Downloading audio..."
+    if isSponsorblockAlive; then
+        yt-dlp --config-locations "${CONFIG_PATH}sponsorblock.conf" -P "$DOWNLOAD_PATH" -x "$1"
+    else
+        yt-dlp --config-locations "${CONFIG_PATH}config" -P "$DOWNLOAD_PATH" -x "$1"
+    fi
+}
+
+# If shared element is a youtube link
+if [[ "$1" =~ ^.*youtu.*$ ]] || [[ "$1" =~ ^.*youtube.*$ ]]; then
+    echo_bold "Downloading...\\n>URL: ${1}"
+    echo_warning "Choose between the following options:"
+    echo_bold "1. Video mode (choose quality and name)"
+    echo_bold "2. Playlist mode"
+    echo_bold "3. Channel mode"
+    echo_bold "4. Audio only mode"
+
+    echo_warning "Enter your choice:"
+    read -p "" choice
+
+    case $choice in
+    1)
+        downloadVideo "$1"
+        ;;
+    2)
+        downloadPlaylist "$1"
+        ;;
+    3)
+        downloadChannel "$1"
+        ;;
+    4)
+        downloadAudio "$1"
+        ;;
+    *)
+        echo_error "\\nInvalid choice!\\n"
+        ;;
+    esac
+
+# Weird case i don't know when it happens
+elif [[ "$1" =~ ^.*nourlselected.*$ ]]; then
+    echo "There was an error"
+
+# If shared element is NOT a youtube link
+else
+    yt-dlp --config-locations "${CONFIG_PATH}config" -P "$DOWNLOAD_PATH" -f 'bestvideo[ext=mp4]+bestaudio[ext=m4a]/best[ext=mp4]/best' "$1"
+fi
+
+read -p "Press enter to continue"

--- a/install.sh
+++ b/install.sh
@@ -31,6 +31,10 @@ error() {
 core_setup() {
     info "--- Starting Core Setup ---"
 
+    # Make all scripts executable
+    info "Making all scripts in scripts/ executable..."
+    find scripts -name "*.sh" -exec chmod +x {} +
+
     # Update and upgrade packages
     pkg update -y && pkg upgrade -y
 
@@ -42,7 +46,6 @@ core_setup() {
 
     # --- Symlink .config directory ---
     info "--- Symlinking .config directory ---"
-    chmod +x scripts/create_symlinks.sh
     ./scripts/create_symlinks.sh
 
     # --- Setup .zshrc ---
@@ -63,7 +66,6 @@ core_setup() {
     cp .zshrc "$HOME/.zshrc"
 
     # Append the custom configuration
-    chmod +x scripts/system/append_custom_config.sh
     ./scripts/system/append_custom_config.sh
 
     success "--- Core Setup Complete ---"
@@ -83,6 +85,7 @@ main_menu() {
     echo "4) Neovim (modern text editor)"
     echo "5) Theming (oh-my-zsh, powerlevel10k, etc.)"
     echo "6) Visual Enhancements (eza, bat, themes)"
+    echo "7) YouTube-DL (for sharing links)"
     echo "----------------------------------------"
     echo "s) Start installation"
     echo "q) Quit"
@@ -133,6 +136,9 @@ main() {
     fi
     if [[ "$choices" == *"6"* ]]; then
         ./scripts/install_visuals.sh
+    fi
+    if [[ "$choices" == *"7"* ]]; then
+        ./scripts/install_youtube_dl.sh
     fi
 
     success "--- All selected components have been installed! ---"

--- a/scripts/install_python.sh
+++ b/scripts/install_python.sh
@@ -16,9 +16,9 @@ info "--- Installing Python Environment ---"
 pkg install -y python
 
 # Upgrade pip
-pip install --upgrade pip
+pip install --upgrade pip --break-system-packages
 
 # Install pipx
-pip install pipx
+pip install pipx --break-system-packages
 
 info "--- Python Environment Installation Complete ---"

--- a/scripts/install_youtube_dl.sh
+++ b/scripts/install_youtube_dl.sh
@@ -1,0 +1,45 @@
+#!/data/data/com.termux/files/usr/bin/bash
+
+# This script installs the YouTube-DL feature.
+
+# --- Colors for output ---
+C_RESET='\033[0m'
+C_BLUE='\033[0;34m'
+C_GREEN='\033[0;32m'
+
+info() {
+    printf "${C_BLUE}%s${C_RESET}\n" "$1"
+}
+
+success() {
+    printf "${C_GREEN}%s${C_RESET}\n" "$1"
+}
+
+info "--- Installing YouTube-DL Feature ---"
+
+# --- Install dependencies ---
+info "Installing dependencies: python, ffmpeg..."
+pkg install -y python ffmpeg
+
+# --- Install yt-dlp ---
+info "Installing yt-dlp..."
+pip install yt-dlp --break-system-packages
+
+# --- Create directories ---
+info "Creating directories..."
+mkdir -p "$HOME/storage/shared/Youtube-DL"
+mkdir -p "$HOME/.config/yt-dlp"
+mkdir -p "$HOME/.termux/bin"
+
+# --- Copy configuration files ---
+info "Copying configuration files..."
+cp -f "assets/youtube-dl/config" "$HOME/.config/yt-dlp/config"
+cp -f "assets/youtube-dl/sponsorblock.conf" "$HOME/.config/yt-dlp/sponsorblock.conf"
+
+# --- Copy and set up termux-url-opener ---
+info "Setting up termux-url-opener..."
+cp -f "assets/youtube-dl/termux-url-opener" "$HOME/.termux/bin/termux-url-opener"
+chmod +x "$HOME/.termux/bin/termux-url-opener"
+
+success "--- YouTube-DL Feature Installation Complete ---"
+info "You can now share YouTube links to Termux to download them."


### PR DESCRIPTION
This commit introduces a new feature to install a YouTube-DL setup for Termux, allowing users to download videos by sharing links.

It also includes the following fixes:
- Adds a command to make all installation scripts executable at the start, fixing the initial "Permission denied" error.
- Adds the `--break-system-packages` flag to `pip install` commands to prevent errors with externally managed Python environments.

The new YouTube-DL feature includes:
- An installation script for `yt-dlp` and `ffmpeg`.
- Configuration files for `yt-dlp` and SponsorBlock.
- A `termux-url-opener` script to handle shared links.
- A new menu option in the main installer.